### PR TITLE
bugfix/break_on_sunday

### DIFF
--- a/app/main/lib/breaks.ts
+++ b/app/main/lib/breaks.ts
@@ -201,13 +201,13 @@ export function checkInWorkingHours(): boolean {
   const now = moment()
 
   const days = {
+    0: settings.workingHoursSunday,
     1: settings.workingHoursMonday,
     2: settings.workingHoursTuesday,
     3: settings.workingHoursWednesday,
     4: settings.workingHoursThursday,
     5: settings.workingHoursFriday,
     6: settings.workingHoursSaturday,
-    7: settings.workingHoursSunday,
   }
 
   const isWorkingDay = days[now.day()]


### PR DESCRIPTION
Fixing mapping from moment according to momentjs docs (https://momentjs.com/docs/#/get-set/day/).

Also, the most break needed day for people starting their week on Sundays :) 

issue: https://github.com/tom-james-watson/breaktimer-app/issues/67#issue-679702253