### PR TITLE
Bugfix : Notifications on MacOS don't respect system settings for alert style

### DIFF
--- a/app/main/lib/notifications.ts
+++ b/app/main/lib/notifications.ts
@@ -22,7 +22,7 @@ export function showNotification(
     silent: process.platform !== "win32",
   });
 
-  if (forceClose) {
+  if (forceClose && process.platform !== "darwin") {
     // Ensure notification doesn't stay open longer than 10 secs
     setTimeout(() => {
       notification.close();


### PR DESCRIPTION
MacOS does not require the flag forceClose. If the notification style is banner, it automatically closes in 5 sec.