### PR TITLE
Ability to start break right away within notification popup

### DIFF
--- a/app/main/lib/store.ts
+++ b/app/main/lib/store.ts
@@ -35,6 +35,7 @@ const defaultSettings: Settings = {
   endBreakEnabled: true,
   skipBreakEnabled: false,
   postponeBreakEnabled: true,
+  startBreakEnabled: true,
 };
 
 const store = new Store<{

--- a/app/renderer/components/Break.tsx
+++ b/app/renderer/components/Break.tsx
@@ -243,7 +243,7 @@ function BreakCountdown(props: BreakCountdownProps) {
                       autoFocus={true}
                       style={{ color: textColor }}
                     >
-                      Start Now
+                      Start
                     </Button>
                   )}
                 </div>

--- a/app/renderer/components/Break.tsx
+++ b/app/renderer/components/Break.tsx
@@ -145,8 +145,10 @@ interface BreakCountdownProps {
   onCountdownOver: () => void;
   onPostponeBreak: () => void;
   onSkipBreak: () => void;
+  onStartBreak: () => void;
   postponeBreakEnabled: boolean;
   skipBreakEnabled: boolean;
+  startBreakEnabled: boolean;
   textColor: string;
 }
 
@@ -156,8 +158,10 @@ function BreakCountdown(props: BreakCountdownProps) {
     onCountdownOver,
     onPostponeBreak,
     onSkipBreak,
+    onStartBreak,
     postponeBreakEnabled,
     skipBreakEnabled,
+    startBreakEnabled,
     textColor,
   } = props;
   const [progress, setProgress] = React.useState<number | null>(null);
@@ -203,30 +207,48 @@ function BreakCountdown(props: BreakCountdownProps) {
       {(skipBreakEnabled || postponeBreakEnabled) && (
         <ControlGroup>
           <ButtonGroup>
-            {skipBreakEnabled && (
-              <Button
-                className={styles.actionButton}
-                onClick={onSkipBreak}
-                icon={<Spinner value={1 - progress} size={16} />}
-                outlined
-                autoFocus={true}
-                style={{ color: textColor }}
-              >
-                Skip
-              </Button>
-            )}
-            {postponeBreakEnabled && (
-              <Button
-                className={styles.actionButton}
-                onClick={onPostponeBreak}
-                icon={<Spinner value={1 - progress} size={16} />}
-                outlined
-                autoFocus={true}
-                style={{ color: textColor }}
-              >
-                Snooze
-              </Button>
-            )}
+            <div>
+              <div>
+                {skipBreakEnabled && (
+                  <Button
+                    className={styles.actionButton}
+                    onClick={onSkipBreak}
+                    icon={<Spinner value={1 - progress} size={16} />}
+                    outlined
+                    autoFocus={true}
+                    style={{ color: textColor }}
+                  >
+                    Skip
+                  </Button>
+                )}
+                {postponeBreakEnabled && (
+                  <Button
+                    className={styles.actionButton}
+                    onClick={onPostponeBreak}
+                    icon={<Spinner value={1 - progress} size={16} />}
+                    outlined
+                    autoFocus={true}
+                    style={{ color: textColor }}
+                  >
+                    Snooze
+                  </Button>
+                )}
+                <div>
+                  {startBreakEnabled && (
+                    <Button
+                      className={styles.actionButton}
+                      onClick={onStartBreak}
+                      icon={<Spinner value={1 - progress} size={16} />}
+                      outlined
+                      autoFocus={true}
+                      style={{ color: textColor }}
+                    >
+                      Start Now
+                    </Button>
+                  )}
+                </div>
+              </div>
+            </div>
           </ButtonGroup>
         </ControlGroup>
       )}
@@ -302,6 +324,10 @@ export default function Break() {
     setClosing(true);
   }, []);
 
+  const handleStartBreak = React.useCallback(() => {
+    setCountingDown(false);
+  }, []);
+
   const handleEndBreak = React.useCallback(() => {
     if (settings?.gongEnabled) {
       // For some reason the end gong sometimes sounds very distorted, so just
@@ -350,10 +376,12 @@ export default function Break() {
                 onCountdownOver={handleCountdownOver}
                 onPostponeBreak={handlePostponeBreak}
                 onSkipBreak={handleSkipBreak}
+                onStartBreak={handleStartBreak}
                 postponeBreakEnabled={
                   settings.postponeBreakEnabled && allowPostpone
                 }
                 skipBreakEnabled={settings.skipBreakEnabled}
+                startBreakEnabled={settings.startBreakEnabled}
                 textColor={settings.textColor}
               />
             ) : (

--- a/app/renderer/components/Settings.tsx
+++ b/app/renderer/components/Settings.tsx
@@ -169,6 +169,12 @@ export default function SettingsEl() {
                   disabled={!settingsDraft.breaksEnabled}
                 />
                 <Switch
+                  label="Allow starting break instantly"
+                  checked={settingsDraft.startBreakEnabled}
+                  onChange={handleSwitchChange.bind(null, "startBreakEnabled")}
+                  disabled={!settingsDraft.breaksEnabled}
+                />
+                <Switch
                   label="Allow snooze break"
                   checked={settingsDraft.postponeBreakEnabled}
                   onChange={handleSwitchChange.bind(

--- a/app/types/settings.ts
+++ b/app/types/settings.ts
@@ -35,4 +35,5 @@ export interface Settings {
   endBreakEnabled: boolean;
   skipBreakEnabled: boolean;
   postponeBreakEnabled: boolean;
+  startBreakEnabled: boolean;
 }


### PR DESCRIPTION
## What?
Add a toggle button to start breaks right away in notification pop up

## Why?
During watching lectures or coding when notification pops up I only have option to wait for the break to start so for that I wanted a start now button. 

Even when I enable snooze I keep pressing snooze just to avoid waiting for notification pop up to complete so I though start button would be great

## How?
This includes a start button in notification pop up under snooze and skip which can be toggled in settings. Used pre-existing code and made some new variables.