### PR TITLE
Show as inactive to avoid interruption

### DIFF
--- a/app/main/lib/windows.ts
+++ b/app/main/lib/windows.ts
@@ -124,8 +124,8 @@ export function createBreakWindows(): void {
         breakWindow.setPosition(display.bounds.x, display.bounds.y);
       }
 
-      breakWindow.show();
-      breakWindow.focus();
+	  // show as inactive (no focus) to avoid interrupting e.g. IME input
+      breakWindow.showInactive();
     });
 
     breakWindow.on("closed", () => {

--- a/app/main/lib/windows.ts
+++ b/app/main/lib/windows.ts
@@ -124,7 +124,7 @@ export function createBreakWindows(): void {
         breakWindow.setPosition(display.bounds.x, display.bounds.y);
       }
 
-	  // show as inactive (no focus) to avoid interrupting e.g. IME input
+      // Show as inactive to avoid stealing focus
       breakWindow.showInactive();
     });
 


### PR DESCRIPTION
The popup currently steals focus when showing up and interrupts e.g. IME input.