### PR TITLE
doc(README): add "How to export or import configuration?" under FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,16 @@ macOS: `/Users/<USERNAME>/Library/Application Support/BreakTimer`
 
 Windows: `C:\Users\<USERNAME>\AppData\Roaming\BreakTimer`
 
+### How to export or import configuration?
+
+The configuration for Breaktimer can be found in `config.json` file. The file can be synced, replaced or symlinked with an existing configuration.
+
+Linux: `/home/<USERNAME>/.config/BreakTimer/config.json`
+
+macOS: `/Users/<USERNAME>/Library/Application Support/BreakTimer/config.json`
+
+Windows: `C:\Users\<USERNAME>\AppData\Roaming\BreakTimer\config.json`
+
 ## Development
 
 See [./DEVELOPMENT.md](DEVELOPMENT.md).


### PR DESCRIPTION
Hi. I was looking for way to export and sync my configuration to dot files. I had custom messages and colour. I thought this would be useful for others too.

This is what I did originally on Mac.

```bash
BREAKTIMER_CONFIG_PATH='~/Library/Application Support/BreakTimer/config.json'
cd {to your dot files folder}
cp $BREAKTIMER_CONFIG_PATH ./breaktimer/config.json
rm $BREAKTIMER_CONFIG_PATH
ln -s $BREAKTIMER_CONFIG_PATH file path
```

I assume the Windows and Linux `config.json` files are at similar location.

If FAQ is not the right place for this, please let me know if there is another place which is right to put the instructions?