### PR TITLE
Add color-scheme for native dark scrollbars

### DIFF
--- a/app/renderer/index.css
+++ b/app/renderer/index.css
@@ -139,6 +139,8 @@ body {
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+
+  color-scheme: light;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -174,6 +176,8 @@ body {
     --sidebar-accent-foreground: oklch(0.985 0 0);
     --sidebar-border: oklch(1 0 0 / 10%);
     --sidebar-ring: oklch(0.556 0 0);
+
+    color-scheme: dark;
   }
 }
 


### PR DESCRIPTION
close #380 

before:
<img width="883" height="617" alt="image" src="https://github.com/user-attachments/assets/182d8c99-53c1-4a43-8df0-c9d9512e9dd3" />

now:
<img width="895" height="621" alt="image" src="https://github.com/user-attachments/assets/246e8f87-bd9a-4946-a738-96b6c51864a3" />
