### PR TITLE
Display user-specified title in simple notification

### DIFF
--- a/app/main/lib/breaks.ts
+++ b/app/main/lib/breaks.ts
@@ -208,7 +208,10 @@ function doBreak(): void {
   log.info(`Break started [type=${settings.notificationType}]`);
 
   if (settings.notificationType === NotificationType.Notification) {
-    showNotification("Time for a break!", stripHtml(settings.breakMessage));
+    showNotification(
+      stripHtml(settings.breakTitle),
+      stripHtml(settings.breakMessage),
+    );
     if (settings.soundType !== SoundType.None) {
       sendIpc(
         IpcChannel.SoundStartPlay,


### PR DESCRIPTION
Use the notification title from the settings also for simple notifications.

<img width="366" height="79" alt="image" src="https://github.com/user-attachments/assets/eabef9eb-52e3-436b-984a-4317927ce61c" />
