### PR TITLE
Add screen lock as a break option

### DIFF
--- a/app/main/lib/breaks.ts
+++ b/app/main/lib/breaks.ts
@@ -110,6 +110,19 @@ function getIdleResetSeconds(): number {
   return getSecondsFromSettings(settings.idleResetLengthSeconds);
 }
 
+// A screen lock counts as a completed break once it has lasted at least this
+// long. By default the threshold is two-thirds of a break's length, derived
+// from the configured break length. A custom threshold can be set instead.
+function getLockResetSeconds(): number {
+  const settings: Settings = getSettings();
+  if (settings.lockUseCustomTime) {
+    return getSecondsFromSettings(settings.lockCustomLengthSeconds);
+  }
+  return getSecondsFromSettings(
+    Math.round((settings.breakLengthSeconds * 2) / 3),
+  );
+}
+
 function getBreakSeconds(): number {
   const settings: Settings = getSettings();
   return getSecondsFromSettings(settings.breakFrequencySeconds);
@@ -118,7 +131,13 @@ function getBreakSeconds(): number {
 function createIdleNotification() {
   const settings: Settings = getSettings();
 
-  if (!settings.idleResetEnabled || idleStart === null) {
+  // Fire for a credit from either auto-detection method. The notification
+  // itself is still gated by idleResetNotification below.
+  if (idleStart === null) {
+    return;
+  }
+
+  if (!settings.idleResetEnabled && !settings.lockScreenAsBreakEnabled) {
     return;
   }
 
@@ -299,6 +318,13 @@ export function checkIdle(): boolean {
   ) as IdleState;
 
   if (state === IdleState.Locked) {
+    if (!settings.lockScreenAsBreakEnabled) {
+      // Locking is not treated as a break, so ignore the lock entirely and let
+      // breaks schedule as normal.
+      lockStart = null;
+      return false;
+    }
+
     if (!lockStart) {
       lockStart = new Date();
       return false;
@@ -306,7 +332,7 @@ export function checkIdle(): boolean {
       const lockSeconds = Number(
         ((+new Date() - +lockStart) / 1000).toFixed(0),
       );
-      return lockSeconds > getIdleResetSeconds();
+      return lockSeconds > getLockResetSeconds();
     }
   }
 

--- a/app/main/lib/breaks.ts
+++ b/app/main/lib/breaks.ts
@@ -247,7 +247,10 @@ function doBreak(): void {
   buildTray();
 }
 
-function checkInWorkingHoursAt(now: moment.Moment, settings: Settings): boolean {
+function checkInWorkingHoursAt(
+  now: moment.Moment,
+  settings: Settings,
+): boolean {
   if (!settings.workingHoursEnabled) {
     return true;
   }

--- a/app/renderer/components/settings.tsx
+++ b/app/renderer/components/settings.tsx
@@ -11,6 +11,7 @@ import AdvancedCard from "./settings/advanced-card";
 import AudioCard from "./settings/audio-card";
 import BackdropCard from "./settings/backdrop-card";
 import BreaksCard from "./settings/breaks-card";
+import LockBreaksCard from "./settings/lock-breaks-card";
 import SettingsCard from "./settings/settings-card";
 import SettingsHeader from "./settings/settings-header";
 import SkipCard from "./settings/skip-card";
@@ -65,6 +66,8 @@ export default function SettingsEl() {
       secondsField = "postponeLengthSeconds";
     } else if (fieldName === "idleResetLength") {
       secondsField = "idleResetLengthSeconds";
+    } else if (fieldName === "lockCustomLength") {
+      secondsField = "lockCustomLengthSeconds";
     } else {
       return;
     }
@@ -94,6 +97,26 @@ export default function SettingsEl() {
     setSettingsDraft({
       ...settingsDraft,
       [field]: checked,
+    });
+  };
+
+  const handleUseCustomLockTimeChange = (checked: boolean): void => {
+    setSettingsDraft((prev) => {
+      if (prev === null) {
+        return prev;
+      }
+
+      // Seed the custom value with the current derived threshold the first time
+      // custom mode is enabled, so the input does not jump.
+      const seedCustomValue = checked && !prev.lockUseCustomTime;
+
+      return {
+        ...prev,
+        lockUseCustomTime: checked,
+        lockCustomLengthSeconds: seedCustomValue
+          ? Math.round((prev.breakLengthSeconds * 2) / 3)
+          : prev.lockCustomLengthSeconds,
+      };
     });
   };
 
@@ -166,6 +189,26 @@ export default function SettingsEl() {
               settingsDraft={settingsDraft}
               onSwitchChange={handleSwitchChange}
               onDateChange={handleDateChange}
+            />
+
+            <LockBreaksCard
+              settingsDraft={settingsDraft}
+              onSwitchChange={handleSwitchChange}
+              onDateChange={handleDateChange}
+              onUseCustomTimeChange={handleUseCustomLockTimeChange}
+            />
+
+            <SettingsCard
+              title="Smart Breaks: Notification"
+              helperText="Show a notification when a break is automatically detected."
+              toggle={{
+                checked: settingsDraft.idleResetNotification,
+                onCheckedChange: (checked) =>
+                  handleSwitchChange("idleResetNotification", checked),
+                disabled:
+                  !settingsDraft.idleResetEnabled &&
+                  !settingsDraft.lockScreenAsBreakEnabled,
+              }}
             />
 
             <SnoozeCard

--- a/app/renderer/components/settings/lock-breaks-card.tsx
+++ b/app/renderer/components/settings/lock-breaks-card.tsx
@@ -1,0 +1,71 @@
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import SettingsCard from "./settings-card";
+import TimeInput from "./time-input";
+import { Settings } from "../../../types/settings";
+
+interface LockBreaksCardProps {
+  settingsDraft: Settings;
+  onSwitchChange: (field: string, checked: boolean) => void;
+  onDateChange: (fieldName: string, newVal: Date) => void;
+  onUseCustomTimeChange: (checked: boolean) => void;
+}
+
+export default function LockBreaksCard({
+  settingsDraft,
+  onSwitchChange,
+  onDateChange,
+  onUseCustomTimeChange,
+}: LockBreaksCardProps) {
+  const derivedSeconds = Math.round((settingsDraft.breakLengthSeconds * 2) / 3);
+  const lockLengthSeconds = settingsDraft.lockUseCustomTime
+    ? settingsDraft.lockCustomLengthSeconds
+    : derivedSeconds;
+
+  return (
+    <SettingsCard
+      title="Smart Breaks: Screen Lock"
+      helperText="Count locking your screen as a break, independent of general inactivity."
+      toggle={{
+        checked: settingsDraft.lockScreenAsBreakEnabled,
+        onCheckedChange: (checked) =>
+          onSwitchChange("lockScreenAsBreakEnabled", checked),
+      }}
+    >
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Label className="text-sm font-medium">
+            Minimum screen lock time
+          </Label>
+          <TimeInput
+            precision="seconds"
+            value={lockLengthSeconds}
+            onChange={(seconds) => {
+              const date = new Date();
+              date.setHours(Math.floor(seconds / 3600));
+              date.setMinutes(Math.floor((seconds % 3600) / 60));
+              date.setSeconds(seconds % 60);
+              onDateChange("lockCustomLength", date);
+            }}
+            disabled={
+              !settingsDraft.lockScreenAsBreakEnabled ||
+              !settingsDraft.lockUseCustomTime
+            }
+          />
+          <p className="text-sm text-muted-foreground">
+            Screen locks shorter than this will not count as breaks. Defaults to
+            two-thirds of your break length.
+          </p>
+        </div>
+        <div className="flex items-center space-x-2">
+          <Switch
+            checked={settingsDraft.lockUseCustomTime}
+            onCheckedChange={onUseCustomTimeChange}
+            disabled={!settingsDraft.lockScreenAsBreakEnabled}
+          />
+          <Label>Use custom time</Label>
+        </div>
+      </div>
+    </SettingsCard>
+  );
+}

--- a/app/renderer/components/settings/smart-breaks-card.tsx
+++ b/app/renderer/components/settings/smart-breaks-card.tsx
@@ -1,5 +1,4 @@
 import { Label } from "@/components/ui/label";
-import { Switch } from "@/components/ui/switch";
 import SettingsCard from "./settings-card";
 import TimeInput from "./time-input";
 import { Settings } from "../../../types/settings";
@@ -17,7 +16,7 @@ export default function SmartBreaksCard({
 }: SmartBreaksCardProps) {
   return (
     <SettingsCard
-      title="Smart Breaks"
+      title="Smart Breaks: Inactivity"
       helperText="Automatically detect natural breaks and reset the break timer."
       toggle={{
         checked: settingsDraft.idleResetEnabled,
@@ -25,32 +24,20 @@ export default function SmartBreaksCard({
           onSwitchChange("idleResetEnabled", checked),
       }}
     >
-      <div className="space-y-4">
-        <div className="space-y-2">
-          <Label className="text-sm font-medium">Minimum idle time</Label>
-          <TimeInput
-            precision="seconds"
-            value={settingsDraft.idleResetLengthSeconds}
-            onChange={(seconds) => {
-              const date = new Date();
-              date.setHours(Math.floor(seconds / 3600));
-              date.setMinutes(Math.floor((seconds % 3600) / 60));
-              date.setSeconds(seconds % 60);
-              onDateChange("idleResetLength", date);
-            }}
-            disabled={!settingsDraft.idleResetEnabled}
-          />
-        </div>
-        <div className="flex items-center space-x-2">
-          <Switch
-            checked={settingsDraft.idleResetNotification}
-            onCheckedChange={(checked) =>
-              onSwitchChange("idleResetNotification", checked)
-            }
-            disabled={!settingsDraft.idleResetEnabled}
-          />
-          <Label>Show notification when break automatically detected</Label>
-        </div>
+      <div className="space-y-2">
+        <Label className="text-sm font-medium">Minimum idle time</Label>
+        <TimeInput
+          precision="seconds"
+          value={settingsDraft.idleResetLengthSeconds}
+          onChange={(seconds) => {
+            const date = new Date();
+            date.setHours(Math.floor(seconds / 3600));
+            date.setMinutes(Math.floor((seconds % 3600) / 60));
+            date.setSeconds(seconds % 60);
+            onDateChange("idleResetLength", date);
+          }}
+          disabled={!settingsDraft.idleResetEnabled}
+        />
       </div>
     </SettingsCard>
   );

--- a/app/types/settings.ts
+++ b/app/types/settings.ts
@@ -48,6 +48,9 @@ export interface Settings {
   idleResetEnabled: boolean;
   idleResetLengthSeconds: number;
   idleResetNotification: boolean;
+  lockScreenAsBreakEnabled: boolean;
+  lockUseCustomTime: boolean;
+  lockCustomLengthSeconds: number;
   soundType: SoundType;
   breakSoundVolume: number;
   breakTitle: string;
@@ -109,6 +112,9 @@ export const defaultSettings: Settings = {
   idleResetEnabled: true,
   idleResetLengthSeconds: 5 * 60,
   idleResetNotification: false,
+  lockScreenAsBreakEnabled: true,
+  lockUseCustomTime: false,
+  lockCustomLengthSeconds: Math.round((2 * 60 * 2) / 3),
   soundType: SoundType.Gong,
   breakSoundVolume: 1,
   breakTitle: "Time for a break.",


### PR DESCRIPTION
## Motivation

I've trained myself to lock my screen whenever I step away. This feature nabs two birds with one stone: it (1) gives the user a setting to start counting a break right away when locking, and (2) inherits an easy, OS-level keyboard shortcut (e.g. `Win+L`) to effectively start a break.

BreakTimer already treats a locked screen as a completed break through `powerMonitor`'s `locked` state (see #236 and #145), but the crediting was wired to the Smart Breaks idle threshold (`idleResetLengthSeconds`, default five minutes), and that same value also drives unlocked idle detection. So a quick `Win+L` under five minutes was never credited, and lowering the idle threshold to fix that also makes the main idle path prone to fire while simply reading or watching without touching the keyboard or mouse.

This decouples the two.

## Changes

- New setting `lockScreenAsBreakEnabled` (default `true`): credits a break once the screen stays locked for a minimum time.
- The minimum lock time defaults to two-thirds of the break length and can be overridden with a custom value (`lockUseCustomTime`, `lockCustomLengthSeconds`). Unlocked idle detection continues to use `idleResetLengthSeconds`, so the two no longer interfere.
- The break settings tab is regrouped into three cards: **Smart Breaks: Inactivity**, **Smart Breaks: Screen Lock**, and a shared **Smart Breaks: Notification**. The "break automatically detected" notification now fires for a screen-lock credit as well, still gated by its own toggle.

## Screenshots

<img width="566" height="825" alt="BreakTimer-Screen-Lock-Settings" src="https://github.com/user-attachments/assets/bb53b87b-9d26-43ae-9064-690893058039" />

## Behavior notes

- Credit is applied on unlock, since the app has to observe how long the session was actually locked.
- When the setting is disabled, a locked screen is ignored and breaks schedule as normal.

## Testing

- `npm run typecheck`, `npm run lint`, `npm run format-check`, and `npm run build` all pass (the four CI gates).
- Manually verified on Windows 11: a short screen lock past the threshold credits a break on unlock, while unlocked idle continues to follow the separate inactivity setting.

Note: the first commit reformats an existing function signature that the pinned Prettier 3.6.2 flags on `master`; it is split out so the feature commit stays clean.

Related: #236, #145
