### PR TITLE
Use Modern Toolset for AppImage

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,9 @@
     "asar": true,
     "artifactName": "${productName}.${ext}",
     "afterPack": "./scripts/afterPack.js",
+    "toolsets": { 
+      "appimage": "1.0.3"
+    },
     "mac": {
       "icon": "resources/icon.icns",
       "entitlements": "./internals/build/entitlements.mac.plist",


### PR DESCRIPTION
Fixes #456 

Following [`electron-build`'s documentation](https://www.electron.build/docs/appimage#modern-toolset-103--static-runtime) for AppImage, I believe this should change the AppImage distribution to use the new recommended static runtime.